### PR TITLE
feat(gemini): set helper func as alias to prefer '~/.gemini/.env' over shell's env for 'gemini' commands

### DIFF
--- a/image/Containerfile
+++ b/image/Containerfile
@@ -125,8 +125,9 @@ COPY --chmod=755 scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 # =====================================
 # Default home provisioning (skel-like)
 # -------------------------------------
-COPY --chmod=644 agents/copilot/*.md    /usr/share/ai-sandbox/agents/copilot/
-COPY --chmod=644 skel/.gitconfig        /usr/share/ai-sandbox/skel/.gitconfig
+COPY --chmod=644 agents/copilot/*.md         /usr/share/ai-sandbox/agents/copilot/
+COPY --chmod=644 skel/.gitconfig             /usr/share/ai-sandbox/skel/.gitconfig
+COPY --chmod=644 skel/gemini-env.sh          /usr/share/ai-sandbox/skel/gemini-env.sh
 
 # =======================
 # Config for krun microvm (needed for crun version < 1.27)

--- a/image/scripts/entrypoint.sh
+++ b/image/scripts/entrypoint.sh
@@ -130,6 +130,22 @@ mkdir -p \
 
 cp -n "$SKEL_D/skel/.gitconfig" "$HOME/.gitconfig" 2>/dev/null || true
 
+# Install sourceable Gemini helper and hook it into .bashrc.
+_gemini_helper_src="$SKEL_D/skel/gemini-env.sh"
+if agent_enabled "gemini" && [ -f "$_gemini_helper_src" ]; then
+    _bashrc="$HOME/.bashrc"
+    [ -f "$_bashrc" ] || : > "$_bashrc"
+    _gemini_marker="# >>> ai-sandbox gemini env helper >>>"
+    if ! grep -F "$_gemini_marker" "$_bashrc" > /dev/null 2>&1; then
+        cat >> "$_bashrc" << 'EOF'
+
+if [ -f "/usr/share/ai-sandbox/skel/gemini-env.sh" ]; then
+    . "/usr/share/ai-sandbox/skel/gemini-env.sh"
+fi
+EOF
+    fi
+fi
+
 # Per-agent provisioning
 agent_enabled "claude"  && provision_agents "claude"  "$HOME/.claude/agents"
 agent_enabled "copilot" && provision_agents "copilot" "$HOME/.copilot/agents"

--- a/image/skel/gemini-env.sh
+++ b/image/skel/gemini-env.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# shellcheck shell=sh
+# Prefer GOOGLE_CLOUD_PROJECT from ~/.gemini/.env when running gemini.
+
+gemini_with_project_env() {
+    _gemini_env_file="$HOME/.gemini/.env"
+    _gemini_project="${GOOGLE_CLOUD_PROJECT:-}"
+
+    if [ -f "$_gemini_env_file" ]; then
+        _gemini_line=$(grep -E \
+            '^[[:space:]]*GOOGLE_CLOUD_PROJECT[[:space:]]*=' \
+            "$_gemini_env_file" | tail -n 1)
+        if [ -n "$_gemini_line" ]; then
+            _gemini_project=${_gemini_line#*=}
+            _gemini_project=$(printf '%s' "$_gemini_project" | sed \
+                's/^[[:space:]]*//; s/[[:space:]]*$//')
+            _gemini_project=$(printf '%s' "$_gemini_project" | sed \
+                "s/^[\"']*//; s/[\"']*$//")
+        fi
+    fi
+
+    if [ -n "$_gemini_project" ]; then
+        GOOGLE_CLOUD_PROJECT="$_gemini_project" command gemini "$@"
+    else
+        command gemini "$@"
+    fi
+}
+
+alias gemini="gemini_with_project_env"


### PR DESCRIPTION
## Proposed changes

Add a Gemini shell helper that prefers `GOOGLE_CLOUD_PROJECT` from
`~/.gemini/.env` when launching the Gemini CLI inside the sandbox.

The helper is a sourceable script in the image `skel/` content and
is sourced from the sandbox user's `~/.bashrc` when the `gemini` agent is
enabled. This allows the sandbox to use the project configured in 
`~/.gemini/.env` instead of the inherited shell environment when present.
This allows the user to have a shell env with a different `GOOGLE_CLOUD_PROJECT`
than the one `gemini` will use. Useful for when configuring multiple AI providers
that use different `GOOGLE_CLOUD_PROJECT` vars.

Behavior:
- If `~/.gemini/.env` contains `GOOGLE_CLOUD_PROJECT=...`, the helper uses that
  value for `gemini`.
- If the variable is missing or empty in `~/.gemini/.env`, the helper falls
  back to the current shell environment.
- `gemini` is aliased to the helper function so the behavior is transparent to
  the user.

## Types of changes

What types of changes does your code introduce to ai-agents-sandbox?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Typo fix (non-breaking change which fixes a typo)
- [ ] Code refactor (non-breaking change which restructures existing code
      without changing its behavior)
- [ ] Documentation Update (non-breaking change which updates documentation)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [x] I have ran the `shellcheck` script to check for shell script issues.
- [ ] I have updated the documentation accordingly.

## Further comments

The helper is sourced from the image-provided skel path rather than copied into
another home-managed location, so rebuilt images can update the helper without
introducing another layer of persisted state.