### PR TITLE
fix: report authentication more accurately, including Google Vertex A…

### DIFF
--- a/image/scripts/entrypoint.sh
+++ b/image/scripts/entrypoint.sh
@@ -71,6 +71,30 @@ check_auth() {
     fi
 }
 
+# Return 0 when Gemini credentials exist in a known persisted path.
+gemini_auth_check() {
+    [ -f "$HOME/.gemini/oauth_creds.json" ] || \
+        [ -f "$HOME/.gemini/credentials.json" ]
+}
+
+# Return 0 when Claude has an active login or API key auth.
+claude_auth_check() {
+    claude auth status > /dev/null 2>&1 || \
+        [ -n "${ANTHROPIC_API_KEY:-}" ] || \
+        [ -f "$HOME/.config/gcloud/application_default_credentials.json" ] || {
+            [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && \
+                [ -f "$GOOGLE_APPLICATION_CREDENTIALS" ]
+        }
+}
+
+# Return 0 when OpenCode can use ADC or an explicit credentials path.
+opencode_auth_check() {
+    [ -f "$HOME/.config/gcloud/application_default_credentials.json" ] || {
+        [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && \
+            [ -f "$GOOGLE_APPLICATION_CREDENTIALS" ]
+    }
+}
+
 # Print the banner header
 banner_header() {
     _mode="$(get_mode)"
@@ -149,7 +173,7 @@ agent_enabled "copilot" &&\
         "gh auth login --scopes 'copilot'"
 
 agent_enabled "gemini" &&\
-    banner_agent "Gemini CLI" "test -f $HOME/.gemini/credentials.json" \
+    banner_agent "Gemini CLI" "gemini_auth_check" \
         "gemini auth login" &&\
     banner_notes \
         "If you used a company plan linked to a google project, you would" \
@@ -158,7 +182,7 @@ agent_enabled "gemini" &&\
 
 agent_enabled "claude" &&\
     banner_agent "Claude Code" \
-        "claude auth status" \
+        "claude_auth_check" \
         "claude auth login  (or: export ANTHROPIC_API_KEY=sk-...)" &&\
     banner_notes \
         "To install though Vertex Ai, connect to Google Cloud with:" \
@@ -166,7 +190,7 @@ agent_enabled "claude" &&\
 
 agent_enabled "opencode" &&\
     banner_agent "Open Code" \
-        "test -f $HOME/.config/opencode/credentials.json" \
+        "opencode_auth_check" \
         "gcloud auth application-default login" &&\
     banner_notes \
         "Required environment variables:" \


### PR DESCRIPTION
## Proposed changes

Fix the startup authentication banner so it reports agent auth state more
accurately inside the sandbox.

This change updates the auth checks in `image/scripts/entrypoint.sh` to match
how credentials are actually persisted and used at runtime:

- Gemini now treats the persisted OAuth credentials file as valid auth instead
  of checking only for a single legacy credentials path.
- OpenCode now treats Google Application Default Credentials as valid auth,
  which matches the documented `gcloud auth application-default login` flow.
- Claude now treats optional Google Vertex AI credentials as valid auth in
  addition to the existing first-party login and API key flows.

This fixes false unauthenticated warnings in the startup banner for Gemini,
OpenCode, and Claude when Vertex AI auth is already present in the sandbox.

## Types of changes

What types of changes does your code introduce to ai-agents-sandbox?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Typo fix (non-breaking change which fixes a typo)
- [ ] Code refactor (non-breaking change which restructures existing code
      without changing its behavior)
- [ ] Documentation Update (non-breaking change which updates documentation)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [x] I have ran the `shellcheck` script to check for shell script issues.
- [ ] I have updated the documentation accordingly.

## Further comments

The previous banner checks caused false negatives even when credentials were already
present.

This change keeps the startup banner behavior the same, but makes the checks
line up with the actual authentication mechanisms already used by the sandbox:
Gemini OAuth credentials, Google ADC for OpenCode, and optional Vertex AI auth
for Claude.