### PR TITLE
feat(config): custom local config

### DIFF
--- a/.ai-agents-sandbox/templates/agents/opencode/config.local.override.example.json
+++ b/.ai-agents-sandbox/templates/agents/opencode/config.local.override.example.json
@@ -1,0 +1,21 @@
+{
+    "mcp": {
+        "jenkins-staging": {
+            "type": "remote",
+            "url": "https://your-jenkins-host/mcp-server/mcp",
+            "enabled": true,
+            "oauth": false,
+            "headers": {
+                "Authorization": "Bearer ${JENKINS_MCP_TOKEN}"
+            },
+            "timeout": 10000
+        }
+    },
+    "lsp": {
+        "gopls": {
+            "disabled": false,
+            "command": ["gopls"],
+            "extensions": [".go"]
+        }
+    }
+}

--- a/.ai-agents-sandbox/templates/entrypoint.post.d/90-example.sh
+++ b/.ai-agents-sandbox/templates/entrypoint.post.d/90-example.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Example post-start hook: runs after normal provisioning.
+
+set -eu
+
+echo "[local-post-hook] Custom post-provision step completed" >&2

--- a/.ai-agents-sandbox/templates/entrypoint.pre.d/10-example.sh
+++ b/.ai-agents-sandbox/templates/entrypoint.pre.d/10-example.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Example pre-start hook: runs before normal provisioning.
+
+set -eu
+
+echo "[local-pre-hook] Running pre-provision checks" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,17 @@ jobs:
         run: |
           zypper --non-interactive refresh
           zypper --non-interactive install --no-recommends \
-            git ShellCheck tar gzip
+            git jq ShellCheck tar gzip
       - uses: actions/checkout@v6
       - name: Run shellcheck
         run: |
           shellcheck -x ai-agents-sandbox.sh
           shellcheck -x printer.sh
           shellcheck -x image/scripts/entrypoint.sh
+          shellcheck -x image/scripts/opencode-bootstrap.sh
+          shellcheck -x tests/opencode-bootstrap-test.sh
+      - name: Run OpenCode bootstrap tests
+        run: sh tests/opencode-bootstrap-test.sh
 
   # ------------------------------------------------------------------
   # Build every image variant on every supported architecture.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 build
 
+# Ignore repo-local customization overlays and secrets
+.ai-agents-sandbox/**
+!.ai-agents-sandbox/
+
 # Ignore everything in sandbox/ (runtime home dir contents)
 sandbox/**
 workspace/**

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,17 @@ build
 
 # Ignore repo-local customization overlays and secrets
 .ai-agents-sandbox/**
-!.ai-agents-sandbox/
+
+# Track only example template files and documentation
 !.ai-agents-sandbox/templates/
-!.ai-agents-sandbox/templates/**
+!.ai-agents-sandbox/templates/entrypoint.pre.d/
+!.ai-agents-sandbox/templates/entrypoint.pre.d/10-example.sh
+!.ai-agents-sandbox/templates/entrypoint.post.d/
+!.ai-agents-sandbox/templates/entrypoint.post.d/90-example.sh
+!.ai-agents-sandbox/templates/agents/
+!.ai-agents-sandbox/templates/agents/opencode/
+!.ai-agents-sandbox/templates/agents/opencode/config.local.override.example.json
+!.ai-agents-sandbox/MIGRATION.md
 
 # Ignore everything in sandbox/ (runtime home dir contents)
 sandbox/**

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ build
 # Ignore repo-local customization overlays and secrets
 .ai-agents-sandbox/**
 !.ai-agents-sandbox/
+!.ai-agents-sandbox/templates/
+!.ai-agents-sandbox/templates/**
 
 # Ignore everything in sandbox/ (runtime home dir contents)
 sandbox/**

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ The script copies injects the version number, passes the `AGENT` build-arg to
 Agent-specific builds only install the tools required by the selected agent,
 resulting in smaller images.
 
+If `.ai-agents-sandbox/Containerfile.local` exists, `build` also creates a
+derived local image named `ai-agents-sandbox[-<agent>]-local:latest`. Use this
+only for image-level customizations such as additional packages, tools, or
+files that must exist before the container starts.
+
 ```bash
 # Verify the build
 podman image inspect ai-agents-sandbox:latest | grep -E "User|Size"
@@ -122,6 +127,30 @@ sh ai-agents-sandbox.sh run <?agent> -w <dir_path>
 ```
 
 > `<?agent>` can be empty to use the all-in-one image.
+>
+> If a matching `-local` image exists, `run` prefers it automatically.
+> Repo-local configuration from `.ai-agents-sandbox/` is also mounted
+> read-only into the container, so most per-user config does not require a
+> rebuild.
+
+### Repo-local customizations
+
+Use `.ai-agents-sandbox/` for local, non-VCS customizations:
+
+```text
+.ai-agents-sandbox/
+├── .env                         # runtime env vars, loaded by podman --env-file
+├── Containerfile.local          # optional derived image for packages/tools
+├── agents/
+│   └── opencode/
+│       └── config.local.override.json
+├── entrypoint.pre.d/            # optional executable hooks, run before provisioning
+└── entrypoint.post.d/           # optional executable hooks, run after provisioning
+```
+
+Use the runtime-mounted files for user-specific configuration, secrets, MCP
+definitions, LSP definitions, and per-agent overrides. Use `Containerfile.local`
+only when you need to change the image itself.
 
 ### Clean the environment
 
@@ -253,6 +282,95 @@ credentials path created by `gcloud auth application-default login`.
 
 If `GOOGLE_CLOUD_PROJECT` is unset, the entrypoint tries to read it from
 `gcloud config get-value project`.
+
+---
+
+## OpenCode: MCP and LSP Configuration
+
+OpenCode configuration is now generated automatically on every container start:
+
+1. The base sandbox flow renders a default `config.json` for Vertex-backed
+  OpenCode from the current environment.
+2. If a local override file exists, it is deep-merged on top of that base
+  config.
+3. The result is written to both `~/.config/opencode/config.json` and
+  `~/.config/opencode/opencode.json`.
+
+That means MCPs, LSPs, and other user-specific OpenCode settings should live in
+the local override file, not in tracked files.
+
+### Location
+
+Create your local OpenCode override in one of these locations (checked in
+order):
+
+```bash
+# Primary (repo-local, gitignored, mounted read-only at runtime)
+.ai-agents-sandbox/agents/opencode/config.local.override.json
+
+# Fallback (persisted sandbox home volume)
+~/.config/opencode/config.local.override.json
+```
+
+### File Format
+
+Create a JSON object containing the settings you want to layer on top of the
+generated base config. For MCPs and LSPs, a typical file looks like this:
+
+```json
+{
+    "mcp": {
+        "jenkins-staging": {
+            "type": "remote",
+            "url": "https://your-jenkins-host/mcp-server/mcp",
+            "enabled": true,
+            "oauth": false,
+            "headers": {
+                "Authorization": "Bearer YOUR_TOKEN_HERE"
+            },
+            "timeout": 10000
+        }
+    },
+    "lsp": {
+        "gopls": {
+            "disabled": false,
+            "command": ["gopls"],
+            "extensions": [".go"]
+        }
+    }
+}
+```
+
+Because the local file is merged into the generated base config, you do not
+need to repeat the default Vertex provider or model settings unless you want to
+override them.
+
+### Security
+
+* **File permissions**: Must be readable/writable by owner only (`0600`).
+* Linux/macOS: `chmod 600 .ai-agents-sandbox/agents/opencode/config.local.override.json`
+* If permissions are broader, the file is ignored and a warning is printed.
+* **Location**: Store repo-local overrides in `.ai-agents-sandbox/`, which is
+  ignored by git.
+* **Merge behavior**: The override must be a JSON object. It is merged into the
+  generated base config with `jq`, so user settings replace or extend the base.
+* **No validation of values**: OpenCode will attempt to use whatever configuration
+  you provide; test connectivity before relying on your setup.
+
+### Validation
+
+After starting the sandbox, verify the final config:
+
+```bash
+cat ~/.config/opencode/config.json | jq .mcp
+cat ~/.config/opencode/config.json | jq .lsp
+```
+
+To inspect the fully merged file:
+
+```bash
+cat ~/.config/opencode/config.json | jq .
+```
 
 ---
 

--- a/ai-agents-sandbox.sh
+++ b/ai-agents-sandbox.sh
@@ -59,6 +59,8 @@ MIN_LIBKRUN_VER="1.18.0"
 # --------
 
 . "${ROOT_D}/printer.sh"
+# shellcheck source=scripts/local-customization.sh
+. "${ROOT_D}/scripts/local-customization.sh"
 
 # ==================
 # Internal functions
@@ -203,34 +205,6 @@ _verify_workspace() {
         print_warning "Falling back to default workspace directory: '$SANDBOX_D_DEFAULT'."
         SANDBOX_D="$SANDBOX_D_DEFAULT"
     fi
-}
-
-_local_overlay_enabled() {
-    [ -f "$LOCAL_CONTAINERFILE" ]
-}
-
-_local_image_name() {
-    printf "%s-local" "$IMG_NAME"
-}
-
-_local_image_exists() {
-    podman image exists "$( _local_image_name ):latest"
-}
-
-_build_local_overlay() {
-    _local_img_name="$( _local_image_name )"
-    print_info "Building local overlay image ${_local_img_name}:${IMG_TAG} ..."
-    if ! podman build \
-        --build-arg "BASE_IMAGE=${IMG_NAME}:${IMG_TAG}" \
-        --tag "${_local_img_name}:${IMG_TAG}" \
-        --tag "${_local_img_name}:latest" \
-        --file "$LOCAL_CONTAINERFILE" \
-        "$USER_CFG_D"; then
-            print_error "Local overlay build failed."
-            return "$FAILURE"
-    fi
-    print_info "Local overlay image built successfully."
-    return "$SUCCESS"
 }
 
 # ================
@@ -593,6 +567,10 @@ Valid agents: $TRUSTED_AGENTS (trusted) or $UNTRUSTED_AGENTS (untrusted)"
     fi
 else
     AGENT="$TRUSTED_AGENTS"
+fi
+
+if [ "$ACTION" = "run" ] || [ "$ACTION" = "build" ]; then
+    _validate_local_customization
 fi
 
 if ! eval "$ACTION"; then

--- a/ai-agents-sandbox.sh
+++ b/ai-agents-sandbox.sh
@@ -28,6 +28,10 @@ ROOT_D="$(cd "$(dirname "$0")" && pwd)"
 IMG_D="${ROOT_D}/image"
 SANDBOX_D_DEFAULT="$ROOT_D/workspace"
 SANDBOX_D="${SANDBOX_D_DEFAULT}"
+USER_CFG_D="${ROOT_D}/.ai-agents-sandbox"
+LOCAL_CONTAINERFILE="${USER_CFG_D}/Containerfile.local"
+LOCAL_ENV_FILE="${USER_CFG_D}/.env"
+LOCAL_MOUNT_D="/usr/share/ai-sandbox/local-host"
 
 # Container variables
 IMG_NAME="ai-agents-sandbox"
@@ -201,6 +205,34 @@ _verify_workspace() {
     fi
 }
 
+_local_overlay_enabled() {
+    [ -f "$LOCAL_CONTAINERFILE" ]
+}
+
+_local_image_name() {
+    printf "%s-local" "$IMG_NAME"
+}
+
+_local_image_exists() {
+    podman image exists "$( _local_image_name ):latest"
+}
+
+_build_local_overlay() {
+    _local_img_name="$( _local_image_name )"
+    print_info "Building local overlay image ${_local_img_name}:${IMG_TAG} ..."
+    if ! podman build \
+        --build-arg "BASE_IMAGE=${IMG_NAME}:${IMG_TAG}" \
+        --tag "${_local_img_name}:${IMG_TAG}" \
+        --tag "${_local_img_name}:latest" \
+        --file "$LOCAL_CONTAINERFILE" \
+        "$USER_CFG_D"; then
+            print_error "Local overlay build failed."
+            return "$FAILURE"
+    fi
+    print_info "Local overlay image built successfully."
+    return "$SUCCESS"
+}
+
 # ================
 # Action functions
 # ----------------
@@ -257,6 +289,11 @@ build() {
             _ret="$FAILURE"
     else
         print_info "Image built successfully."
+        if _local_overlay_enabled; then
+            if ! _build_local_overlay; then
+                _ret="$FAILURE"
+            fi
+        fi
     fi
     return "$_ret"
 }
@@ -264,6 +301,8 @@ build() {
 # callback for run action
 run() {
     _ret="$SUCCESS"
+    _run_image="$IMG_NAME"
+    _build_hint="sh ai-agents-sandbox.sh build"
     
     if [ "$(uname -s)" = "Darwin" ] && [ "$USE_MICROVM" = "1" ]; then
         print_warning "[!] macOS detected — KVM is not available;"
@@ -375,6 +414,13 @@ run() {
         --env "AI_GID=${AI_USER_GID}" \
         --env "AI_SANDBOX_VERSION=${IMG_TAG}"
 
+    if [ -f "$LOCAL_ENV_FILE" ]; then
+        set -- "$@" --env-file "$LOCAL_ENV_FILE"
+    fi
+    if [ -d "$USER_CFG_D" ]; then
+        set -- "$@" --volume "$USER_CFG_D:${LOCAL_MOUNT_D}:ro,z"
+    fi
+
     # Forward cloud/relay settings needed by Vertex-backed OpenCode sessions.
     if [ -n "$GOOGLE_CLOUD_PROJECT" ]; then
         set -- "$@" --env "GOOGLE_CLOUD_PROJECT=$GOOGLE_CLOUD_PROJECT"
@@ -398,11 +444,23 @@ run() {
         # required
         set -- "$@" --annotation krun.ram_mib=8192 --annotation krun.cpus=4
     fi
-    _args=$*
+
+    if _local_overlay_enabled; then
+        if _local_image_exists; then
+            _run_image="$( _local_image_name )"
+            print_info "Using local overlay image ${_run_image}:latest."
+        else
+            if [ "$IMG_NAME" != "ai-agents-sandbox" ]; then
+                _build_hint="${_build_hint} ${AGENT}"
+            fi
+            print_warning "Local overlay requested but image '${IMG_NAME}-local:latest' is missing."
+            print_warning "     -> Run '${_build_hint}' to build it."
+        fi
+    fi
+
     print_info "Starting isolated container..."
-    _cmd="podman run -it $_args ${IMG_NAME}:latest"
-    print_debug "$_cmd"
-    if ! eval "$_cmd"; then
+    print_debug "podman run -it $* ${_run_image}:latest"
+    if ! podman run -it "$@" "${_run_image}:latest"; then
         print_error "Failed to start container ${CTN_NAME}."
         _ret="$FAILURE"
     fi

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,8 +28,15 @@ measures.
 
 ## Project structure
 
-```
+```text
 ai-agents-sandbox/
+│
+├── .ai-agents-sandbox/         # Local, gitignored user overrides and optional local overlay
+│   ├── .env                    # Runtime env vars passed by podman --env-file
+│   ├── Containerfile.local     # Optional derived image layer for extra packages/tools
+│   ├── agents/                 # Per-agent local config copied into the container home
+│   ├── entrypoint.pre.d/       # Optional executable hooks run before provisioning
+│   └── entrypoint.post.d/      # Optional executable hooks run after provisioning
 │
 ├── image/
 │   ├── Containerfile          # Image definition — no secrets; AGENT build-arg for slim builds
@@ -38,9 +45,11 @@ ai-agents-sandbox/
 │   │   ├── copilot/           # Copilot agent definitions (provisioned to ~/.copilot/agents/)
 │   │   └── gemini/            # Gemini sub-agent definitions (provisioned to ~/.gemini/agents/)
 │   ├── skel/
-│   │   └── .gitconfig         # Default git config (provisioned to ~/.gitconfig on first run)
+│   │   ├── .gitconfig         # Default git config (provisioned to ~/.gitconfig on first run)
+│   │   └── opencode/          # Base OpenCode config template rendered at startup
 │   └── scripts/
 │       ├── entrypoint.sh      # Startup script — home provisioning + auth status check
+│       ├── opencode-bootstrap.sh  # Renders base OpenCode config, then merges local overrides
 │       └── healthcheck.sh     # Container health verification
 │
 ├── workspace/                 # ← Mounted as /home/aiuser (persistent, gitignored)
@@ -55,12 +64,14 @@ ai-agents-sandbox/
 
 A `podman volume` is used for the aiuser HOME directory `/home/aiuser`. It keeps
 authentication status between runs. The `workspace/` will be mounted into
-`/home/aiuser/workspace/`. A perfect place to store working project, it can be
-shared between different ai-agents-sandboxes. At every start, the entrypoint
-automatically provisions:
+`/home/aiuser/workspace/`. If `.ai-agents-sandbox/` exists, it is also mounted
+read-only into the container so local hooks and per-agent config can be applied
+without rebuilding the image. At every start, the entrypoint automatically
+provisions:
 
 - `~/.gitconfig` — default git configuration
 - `~/.copilot/agents/` — Copilot agent definitions
+- `~/.config/opencode/config.json` — generated OpenCode base config
 - `~/workspace/` — your projects directory
 
 Auth token directories (`.config/gh/`, `.gemini/`, `.claude/`) are created
@@ -76,7 +87,7 @@ automatically on first login. All runtime content is excluded from git via
 | GitHub Copilot | `copilot` | `gh auth login` | Trusted |
 | Gemini CLI | `gemini` | `gemini auth login` | Trusted |
 | Claude Code | `claude` | `claude auth login` | Trusted |
-| OpenCode | `opencode` | configure `opencode.json` | Trusted |
+| OpenCode | `opencode` | `gcloud auth application-default login` | Trusted |
 | antigravity | `agye` | run `agy` | Trusted |
 | Hermes Agent | `hermes` | `hermes setup` | Untrusted |
 
@@ -113,7 +124,7 @@ automatically on first login. All runtime content is excluded from git via
 | Measure | Effect |
 |---|---|
 | Dedicated home volume | The real `$HOME` is never mounted |
-| Explicit volume whitelist | Only `sandbox/` is mounted as `/home/aiuser` |
+| Explicit volume whitelist | Only the sandbox home volume, `workspace/`, and optional `.ai-agents-sandbox/` are mounted |
 | `--tmpfs /tmp:noexec,nosuid` | `/tmp` is in RAM, non-executable, non-setuid |
 | No Docker / Podman socket | Container cannot spawn other containers |
 
@@ -227,6 +238,32 @@ run            # new container, everything intact ✅
 > `clean all` removes auth token directories but preserves `workspace/`.
 > Defaults (`.gitconfig`, `.copilot/agents/`) are re-provisioned from the
 > image on the next `run`.
+
+---
+
+## Local customization flow
+
+Use `.ai-agents-sandbox/` for non-VCS user customizations.
+
+- `.env` is passed at runtime with `podman --env-file`.
+- `agents/<agent>/` is mounted read-only and copied into the agent's home config
+  path on startup.
+- `entrypoint.pre.d/` and `entrypoint.post.d/` contain executable hooks that run
+  before and after normal provisioning.
+- `Containerfile.local` is optional and only needed for image-level changes such
+  as extra packages or additional binaries.
+
+For OpenCode specifically, the startup flow is:
+
+1. Render the base config from `image/skel/opencode/config.template.json`.
+2. Load a local override from `.ai-agents-sandbox/agents/opencode/config.local.override.json`
+   when present, otherwise from `~/.config/opencode/config.local.override.json`.
+3. Deep-merge the local override into the generated base config.
+4. Write the merged result to both `~/.config/opencode/config.json` and
+   `~/.config/opencode/opencode.json`.
+
+This keeps base provider/model defaults in the image while allowing user-local
+MCP, LSP, and other OpenCode settings to stay out of version control.
 
 ---
 

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -137,6 +137,8 @@ RUN case " $AGENT " in *" gemini "*) \
 # Copy scripts
 # ------------
 COPY --chmod=755 scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --chmod=755 scripts/opencode-bootstrap.sh \
+    /usr/local/bin/opencode-bootstrap.sh
 
 # =====================================
 # Default home provisioning (skel-like)
@@ -144,6 +146,11 @@ COPY --chmod=755 scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --chmod=644 agents/copilot/*.md         /usr/share/ai-sandbox/agents/copilot/
 COPY --chmod=644 skel/.gitconfig             /usr/share/ai-sandbox/skel/.gitconfig
 COPY --chmod=644 skel/gemini-env.sh          /usr/share/ai-sandbox/skel/gemini-env.sh
+COPY --chmod=644 skel/opencode/config.template.json \
+    /usr/share/ai-sandbox/skel/opencode/config.template.json
+RUN mkdir -p /usr/share/ai-sandbox/local/entrypoint.pre.d \
+    /usr/share/ai-sandbox/local/entrypoint.post.d \
+    /usr/share/ai-sandbox/local/agents
 
 # =======================
 # Config for krun microvm (needed for crun version < 1.27)

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -139,6 +139,8 @@ RUN case " $AGENT " in *" gemini "*) \
 COPY --chmod=755 scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --chmod=755 scripts/opencode-bootstrap.sh \
     /usr/local/bin/opencode-bootstrap.sh
+COPY --chmod=644 scripts/local-provision.sh \
+    /usr/share/ai-sandbox/scripts/local-provision.sh
 
 # =====================================
 # Default home provisioning (skel-like)

--- a/image/scripts/entrypoint.sh
+++ b/image/scripts/entrypoint.sh
@@ -20,6 +20,12 @@
 # ----------------
 
 SKEL_D="/usr/share/ai-sandbox"
+LOCAL_IMAGE_D="${SKEL_D}/local"
+LOCAL_HOST_D="${SKEL_D}/local-host"
+IMAGE_ENTRYPOINT_PRE_D="${LOCAL_IMAGE_D}/entrypoint.pre.d"
+IMAGE_ENTRYPOINT_POST_D="${LOCAL_IMAGE_D}/entrypoint.post.d"
+HOST_ENTRYPOINT_PRE_D="${LOCAL_HOST_D}/entrypoint.pre.d"
+HOST_ENTRYPOINT_POST_D="${LOCAL_HOST_D}/entrypoint.post.d"
 # Default agent list (contains both trusted and untrusted agents)
 # filtering happens in ai-agents-sandbox.sh script
 AGENT="${AGENT:-claude copilot gemini opencode antigravity hermes-agent}"
@@ -43,6 +49,35 @@ provision_agents() {
             fi
         done
     fi
+}
+
+provision_overlay_agents() {
+    _overlay_root="$1"
+    _agent_name="$2"
+    _target_dir="$3"
+    _src_dir="${_overlay_root}/agents/${_agent_name}"
+    if [ -d "$_src_dir" ]; then
+        mkdir -p "$_target_dir"
+        cp -R "$_src_dir"/. "$_target_dir"/ 2>/dev/null || true
+    fi
+}
+
+provision_local_agents() {
+    _agent_name="$1"
+    _target_dir="$2"
+    provision_overlay_agents "$LOCAL_IMAGE_D" "$_agent_name" "$_target_dir"
+    provision_overlay_agents "$LOCAL_HOST_D" "$_agent_name" "$_target_dir"
+}
+
+run_hook_dir() {
+    _hook_dir="$1"
+    [ -d "$_hook_dir" ] || return 0
+
+    for _hook in "$_hook_dir"/*; do
+        [ -f "$_hook" ] || continue
+        [ -x "$_hook" ] || continue
+        "$_hook"
+    done
 }
 
 # Return 0 if agent is enabled, 1 otherwise
@@ -147,6 +182,9 @@ if [ "$(id -u)" = "0" ] && id aiuser >/dev/null 2>&1; then
     exec setpriv --reuid="$_uid" --regid="$_guid" --init-groups "$0" "$@"
 fi
 
+run_hook_dir "$IMAGE_ENTRYPOINT_PRE_D"
+run_hook_dir "$HOST_ENTRYPOINT_PRE_D"
+
 # Home provisioning (first-run or after clean)
 # Files are copied only if they do not already exist (cp -n).
 # This allows users to customise their home without losing changes on restart.
@@ -181,6 +219,36 @@ agent_enabled "antigravity" &&\
 agent_enabled "opencode" &&\
     mkdir -p "$HOME/.config/opencode" &&\
     provision_agents "opencode" "$HOME/.config/opencode"
+
+# Apply user-local per-agent overrides after the packaged defaults.
+agent_enabled "claude" &&\
+    provision_local_agents "claude" "$HOME/.claude/agents"
+agent_enabled "copilot" &&\
+    provision_local_agents "copilot" "$HOME/.copilot/agents"
+agent_enabled "gemini" &&\
+    provision_local_agents "gemini" "$HOME/.gemini/agents"
+agent_enabled "antigravity" &&\
+    provision_local_agents "antigravity" "$HOME/.gemini/antigravity-cli"
+agent_enabled "opencode" &&\
+    provision_local_agents "opencode" "$HOME/.config/opencode"
+agent_enabled "hermes-agent" &&\
+    provision_local_agents "hermes-agent" "$HOME/.hermes"
+
+# If GOOGLE_CLOUD_PROJECT is not forwarded by the launcher, try to
+# read it from the persisted gcloud configuration (best-effort).
+if agent_enabled "opencode" && [ -z "$GOOGLE_CLOUD_PROJECT" ] \
+    && command -v gcloud > /dev/null 2>&1; then
+    _gc_proj=$(gcloud config get-value project 2>/dev/null) || true
+    case "${_gc_proj:-}" in
+        ''|'(unset)') ;;
+        *)  export GOOGLE_CLOUD_PROJECT="$_gc_proj" ;;
+    esac
+fi
+
+agent_enabled "opencode" && /usr/local/bin/opencode-bootstrap.sh
+
+run_hook_dir "$IMAGE_ENTRYPOINT_POST_D"
+run_hook_dir "$HOST_ENTRYPOINT_POST_D"
 
 # Print the banner with agent status and authentication hints
 banner_header

--- a/image/scripts/entrypoint.sh
+++ b/image/scripts/entrypoint.sh
@@ -36,49 +36,8 @@ BANNER_HEADLINE="AI AGENTS SANDBOX - $VERSION"
 # Internal functions
 # ------------------
 
-# Provision sub-agents for each relevant agent
-provision_agents() {
-    _agent_name="$1"
-    _target_dir="$2"
-    _src_dir="$SKEL_D/agents/${_agent_name}"
-    if [ -d "$_src_dir" ]; then
-        mkdir -p "$_target_dir"
-        for f in "$_src_dir"/*; do
-            if [ -f "$f" ]; then
-                cp -n "$f" "$_target_dir/" 2>/dev/null || true
-            fi
-        done
-    fi
-}
-
-provision_overlay_agents() {
-    _overlay_root="$1"
-    _agent_name="$2"
-    _target_dir="$3"
-    _src_dir="${_overlay_root}/agents/${_agent_name}"
-    if [ -d "$_src_dir" ]; then
-        mkdir -p "$_target_dir"
-        cp -R "$_src_dir"/. "$_target_dir"/ 2>/dev/null || true
-    fi
-}
-
-provision_local_agents() {
-    _agent_name="$1"
-    _target_dir="$2"
-    provision_overlay_agents "$LOCAL_IMAGE_D" "$_agent_name" "$_target_dir"
-    provision_overlay_agents "$LOCAL_HOST_D" "$_agent_name" "$_target_dir"
-}
-
-run_hook_dir() {
-    _hook_dir="$1"
-    [ -d "$_hook_dir" ] || return 0
-
-    for _hook in "$_hook_dir"/*; do
-        [ -f "$_hook" ] || continue
-        [ -x "$_hook" ] || continue
-        "$_hook"
-    done
-}
+# shellcheck source=image/scripts/local-provision.sh
+. "/usr/share/ai-sandbox/scripts/local-provision.sh"
 
 # Return 0 if agent is enabled, 1 otherwise
 agent_enabled() {

--- a/image/scripts/local-provision.sh
+++ b/image/scripts/local-provision.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# local-provision.sh - Local overlay provisioning helpers for entrypoint.sh.
+#
+# Sourced by entrypoint.sh. Provides functions to provision agent config files
+# from the base skel directory and from any local overlay directories
+# (image-baked or host-mounted).
+#
+# Requires the following variables to be set by the caller:
+#   SKEL_D         - Path to /usr/share/ai-sandbox
+#   LOCAL_IMAGE_D  - Path to image-baked local overlay root
+#   LOCAL_HOST_D   - Path to host-mounted local overlay root
+
+# Copy base agent files (non-destructive: skips existing files).
+provision_agents() {
+    _agent_name="$1"
+    _target_dir="$2"
+    _src_dir="${SKEL_D}/agents/${_agent_name}"
+    if [ -d "$_src_dir" ]; then
+        mkdir -p "$_target_dir"
+        for f in "$_src_dir"/*; do
+            [ -f "$f" ] || continue
+            cp -n "$f" "$_target_dir/" 2>/dev/null || true
+        done
+    fi
+}
+
+# Copy overlay agent files from a given overlay root (additive, overwrites).
+provision_overlay_agents() {
+    _overlay_root="$1"
+    _agent_name="$2"
+    _target_dir="$3"
+    _src_dir="${_overlay_root}/agents/${_agent_name}"
+    if [ -d "$_src_dir" ]; then
+        mkdir -p "$_target_dir"
+        cp -R "$_src_dir"/. "$_target_dir"/ 2>/dev/null || true
+    fi
+}
+
+# Apply local overrides from both image-baked and host-mounted overlay roots.
+provision_local_agents() {
+    _agent_name="$1"
+    _target_dir="$2"
+    provision_overlay_agents "$LOCAL_IMAGE_D" "$_agent_name" "$_target_dir"
+    provision_overlay_agents "$LOCAL_HOST_D" "$_agent_name" "$_target_dir"
+}
+
+# Execute every executable file in a hook directory, in lexical order.
+# Stops on first non-zero exit.
+run_hook_dir() {
+    _hook_dir="$1"
+    [ -d "$_hook_dir" ] || return 0
+
+    for _hook in "$_hook_dir"/*; do
+        [ -f "$_hook" ] || continue
+        [ -x "$_hook" ] || continue
+        "$_hook"
+    done
+}

--- a/image/scripts/opencode-bootstrap.sh
+++ b/image/scripts/opencode-bootstrap.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 # opencode-bootstrap.sh - render OpenCode config from base and local overlays.
+# This script is intended to be run at container startup to generate the OpenCode
+# configuration file based on a template and any local overrides.
 
 set -eu
 
-LOCAL_IMAGE_D="/usr/share/ai-sandbox/local"
-LOCAL_HOST_D="/usr/share/ai-sandbox/local-host"
+LOCAL_IMAGE_D="${OPENCODE_LOCAL_IMAGE_DIR:-/usr/share/ai-sandbox/local}"
+LOCAL_HOST_D="${OPENCODE_LOCAL_HOST_DIR:-/usr/share/ai-sandbox/local-host}"
 
 expand_file_env_refs() {
     _src="$1"
@@ -24,6 +26,11 @@ expand_file_env_refs() {
     ' "$_src" > "$_dst"
 }
 
+# Looks for an override file in several locations, with the following precedence:
+# 1. The file specified by the OPENCODE_CONFIG_OVERRIDE_FILE environment variable, if set.
+# 2. A file named config.local.override.json in the LOCAL_HOST_D directory.
+# 3. A file named config.local.override.json in the LOCAL_IMAGE_D directory.
+# 4. A file named config.local.override.json in the target OpenCode config directory.
 pick_override_file() {
     _opencode_dir="$1"
 
@@ -45,13 +52,15 @@ pick_override_file() {
     return 1
 }
 
+# Takes a base config file and an override file, validates the
+# override, and merges it into the base config with precedence.
 apply_local_override() {
     _base_cfg="$1"
     _override_cfg="$2"
 
     [ -f "$_override_cfg" ] || return 0
 
-    _mode="$(stat -c '%a' "$_override_cfg" 2>/dev/null || true)"
+    _mode="$(_file_mode "$_override_cfg" 2>/dev/null || true)"
     case "$_mode" in
         600|0600) ;;
         *)
@@ -71,9 +80,23 @@ apply_local_override() {
     mv "$_merged_cfg" "$_base_cfg"
 }
 
+_file_mode() {
+    _path="$1"
+    if stat -c '%a' "$_path" > /dev/null 2>&1; then
+        stat -c '%a' "$_path"
+        return 0
+    fi
+    if stat -f '%OLp' "$_path" > /dev/null 2>&1; then
+        stat -f '%OLp' "$_path"
+        return 0
+    fi
+    return 1
+}
+
+# Normalize the OLLAMA_BASE_URL environment variable based on various inputs and fallbacks.
 normalize_ollama_base_url() {
-    if [ -n "${OPENCODE_OLLAMA_BASE_URL:-}" ]; then
-        _oc_ollama="$OPENCODE_OLLAMA_BASE_URL"
+    if [ -n "${OLLAMA_BASE_URL:-}" ]; then
+        _oc_ollama="$OLLAMA_BASE_URL"
         _oc_ollama_src="base_url"
     elif [ -n "${OLLAMA_HOST:-}" ]; then
         _oc_ollama="$OLLAMA_HOST"
@@ -94,11 +117,11 @@ normalize_ollama_base_url() {
             ;;
     esac
 
-    export OPENCODE_OLLAMA_BASE_URL="$_oc_ollama"
+    export OLLAMA_BASE_URL="$_oc_ollama"
 }
 
 _opencode_dir="${HOME}/.config/opencode"
-_template="/usr/share/ai-sandbox/skel/opencode/config.template.json"
+_template="${OPENCODE_TEMPLATE_FILE:-/usr/share/ai-sandbox/skel/opencode/config.template.json}"
 _cfg="${_opencode_dir}/config.json"
 _legacy_cfg="${_opencode_dir}/opencode.json"
 
@@ -107,6 +130,7 @@ mkdir -p "$_opencode_dir"
 normalize_ollama_base_url
 export VERTEX_LOCATION="${VERTEX_LOCATION:-global}"
 
+# If the template exists, render it with environment variable substitution, then apply any local overrides.
 if [ -f "$_template" ]; then
     expand_file_env_refs "$_template" "$_cfg"
     if _override_cfg="$(pick_override_file "$_opencode_dir")"; then

--- a/image/scripts/opencode-bootstrap.sh
+++ b/image/scripts/opencode-bootstrap.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+# opencode-bootstrap.sh - render OpenCode config from base and local overlays.
+
+set -eu
+
+LOCAL_IMAGE_D="/usr/share/ai-sandbox/local"
+LOCAL_HOST_D="/usr/share/ai-sandbox/local-host"
+
+expand_file_env_refs() {
+    _src="$1"
+    _dst="$2"
+
+    awk '
+        {
+            out = $0
+            while (match(out, /\$\{[A-Za-z_][A-Za-z0-9_]*\}/)) {
+                key = substr(out, RSTART + 2, RLENGTH - 3)
+                rep = ENVIRON[key]
+                out = substr(out, 1, RSTART - 1) \
+                    rep substr(out, RSTART + RLENGTH)
+            }
+            print out
+        }
+    ' "$_src" > "$_dst"
+}
+
+pick_override_file() {
+    _opencode_dir="$1"
+
+    if [ -n "${OPENCODE_CONFIG_OVERRIDE_FILE:-}" ]; then
+        printf "%s" "$OPENCODE_CONFIG_OVERRIDE_FILE"
+        return 0
+    fi
+
+    for _candidate in \
+        "${LOCAL_HOST_D}/agents/opencode/config.local.override.json" \
+        "${LOCAL_IMAGE_D}/agents/opencode/config.local.override.json" \
+        "${_opencode_dir}/config.local.override.json"; do
+        if [ -f "$_candidate" ]; then
+            printf "%s" "$_candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+apply_local_override() {
+    _base_cfg="$1"
+    _override_cfg="$2"
+
+    [ -f "$_override_cfg" ] || return 0
+
+    _mode="$(stat -c '%a' "$_override_cfg" 2>/dev/null || true)"
+    case "$_mode" in
+        600|0600) ;;
+        *)
+            echo "[opencode-bootstrap] Ignoring override with insecure permissions: $_override_cfg" >&2
+            return 0
+            ;;
+    esac
+
+    if ! jq -e 'type == "object"' "$_override_cfg" >/dev/null 2>&1; then
+        echo "[opencode-bootstrap] Ignoring invalid override file: $_override_cfg" >&2
+        echo "[opencode-bootstrap] Override must be a JSON object." >&2
+        return 0
+    fi
+
+    _merged_cfg="${_base_cfg}.merged"
+    jq -s '.[0] * .[1]' "$_base_cfg" "$_override_cfg" > "$_merged_cfg"
+    mv "$_merged_cfg" "$_base_cfg"
+}
+
+normalize_ollama_base_url() {
+    if [ -n "${OPENCODE_OLLAMA_BASE_URL:-}" ]; then
+        _oc_ollama="$OPENCODE_OLLAMA_BASE_URL"
+        _oc_ollama_src="base_url"
+    elif [ -n "${OLLAMA_HOST:-}" ]; then
+        _oc_ollama="$OLLAMA_HOST"
+        _oc_ollama_src="ollama_host"
+    else
+        _oc_ollama="http://127.0.0.1:11434/v1"
+        _oc_ollama_src="default"
+    fi
+
+    case "$_oc_ollama" in
+        http://*|https://*) ;;
+        *) _oc_ollama="http://${_oc_ollama}" ;;
+    esac
+
+    case "$_oc_ollama_src" in
+        ollama_host|default)
+            _oc_ollama="${_oc_ollama%/}/v1"
+            ;;
+    esac
+
+    export OPENCODE_OLLAMA_BASE_URL="$_oc_ollama"
+}
+
+_opencode_dir="${HOME}/.config/opencode"
+_template="/usr/share/ai-sandbox/skel/opencode/config.template.json"
+_cfg="${_opencode_dir}/config.json"
+_legacy_cfg="${_opencode_dir}/opencode.json"
+
+mkdir -p "$_opencode_dir"
+
+normalize_ollama_base_url
+export VERTEX_LOCATION="${VERTEX_LOCATION:-global}"
+
+if [ -f "$_template" ]; then
+    expand_file_env_refs "$_template" "$_cfg"
+    if _override_cfg="$(pick_override_file "$_opencode_dir")"; then
+        apply_local_override "$_cfg" "$_override_cfg"
+    fi
+    cp "$_cfg" "$_legacy_cfg" 2>/dev/null || true
+fi

--- a/image/scripts/opencode-bootstrap.sh
+++ b/image/scripts/opencode-bootstrap.sh
@@ -57,6 +57,7 @@ pick_override_file() {
 apply_local_override() {
     _base_cfg="$1"
     _override_cfg="$2"
+    _expanded_override="${_base_cfg}.override.expanded"
 
     [ -f "$_override_cfg" ] || return 0
 
@@ -69,14 +70,18 @@ apply_local_override() {
             ;;
     esac
 
-    if ! jq -e 'type == "object"' "$_override_cfg" >/dev/null 2>&1; then
+    expand_file_env_refs "$_override_cfg" "$_expanded_override"
+
+    if ! jq -e 'type == "object"' "$_expanded_override" >/dev/null 2>&1; then
+        rm -f "$_expanded_override"
         echo "[opencode-bootstrap] Ignoring invalid override file: $_override_cfg" >&2
         echo "[opencode-bootstrap] Override must be a JSON object." >&2
         return 0
     fi
 
     _merged_cfg="${_base_cfg}.merged"
-    jq -s '.[0] * .[1]' "$_base_cfg" "$_override_cfg" > "$_merged_cfg"
+    jq -s '.[0] * .[1]' "$_base_cfg" "$_expanded_override" > "$_merged_cfg"
+    rm -f "$_expanded_override"
     mv "$_merged_cfg" "$_base_cfg"
 }
 

--- a/image/skel/opencode/config.template.json
+++ b/image/skel/opencode/config.template.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://opencode.ai/config.json",
+    "enabled_providers": [
+        "google-vertex"
+    ],
+    "provider": {
+        "google-vertex": {
+            "npm": "@google-cloud/vertexai",
+            "name": "Vertex",
+            "options": {
+                "projectId": "${GOOGLE_CLOUD_PROJECT}",
+                "location": "${VERTEX_LOCATION}"
+            }
+        }
+    },
+    "model": "google-vertex/gemini-2.0-flash"
+}

--- a/image/skel/opencode/config.template.json
+++ b/image/skel/opencode/config.template.json
@@ -1,7 +1,9 @@
 {
     "$schema": "https://opencode.ai/config.json",
     "enabled_providers": [
-        "google-vertex"
+        "ollama",
+        "google-vertex",
+        "github-copilot"
     ],
     "provider": {
         "google-vertex": {
@@ -11,7 +13,39 @@
                 "projectId": "${GOOGLE_CLOUD_PROJECT}",
                 "location": "${VERTEX_LOCATION}"
             }
+        },
+        "ollama": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "Ollama",
+            "options": {
+                "baseURL": "${OLLAMA_BASE_URL}"
+            },
+            "models": {
+                "default:latest": {
+                    "name": "default:latest"
+                }
+            }
+        },
+        "github-copilot": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "GitHub Copilot",
+            "options": {
+                "baseURL": "https://api.githubcopilot.com"
+            }
         }
     },
-    "model": "google-vertex/gemini-2.0-flash"
+    "mcp": {
+        "jenkins": {
+            "type": "remote",
+            "url": "${JENKINS_MCP_URL}",
+            "enabled": true,
+            "oauth": false,
+            "headers": {
+                "Authorization": "Bearer ${JENKINS_MCP_TOKEN}"
+            },
+            "timeout": 10000
+        }
+    },
+    "lsp": {},
+    "model": "ollama/default:latest"
 }

--- a/scripts/local-customization.sh
+++ b/scripts/local-customization.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# local-customization.sh - Local user overlay helpers for ai-agents-sandbox.
+#
+# Sourced by ai-agents-sandbox.sh. Provides validation, detection and build
+# functions for the .ai-agents-sandbox/ repo-local customization directory.
+#
+# Requires the following variables to be set by the caller:
+#   USER_CFG_D         - Path to the local customization directory.
+#   LOCAL_CONTAINERFILE - Path to the local Containerfile.
+#   IMG_NAME           - Base container image name.
+#   IMG_TAG            - Container image tag.
+#   ACTION             - Current launcher action (build|run|...).
+#   SUCCESS / FAILURE  - Return code constants.
+
+# Return the file permission bits (octal) for a path, portably across Linux
+# (stat -c) and macOS/BSD (stat -f).
+_file_mode() {
+    _path="$1"
+    if stat -c '%a' "$_path" > /dev/null 2>&1; then
+        stat -c '%a' "$_path"
+        return 0
+    fi
+    if stat -f '%OLp' "$_path" > /dev/null 2>&1; then
+        stat -f '%OLp' "$_path"
+        return 0
+    fi
+    return 1
+}
+
+# Emit a warning for every non-executable file found in a hook directory.
+_warn_non_executable_hooks() {
+    _hook_dir="$1"
+    [ -d "$_hook_dir" ] || return 0
+    for _hook in "$_hook_dir"/*; do
+        [ -f "$_hook" ] || continue
+        [ -x "$_hook" ] && continue
+        print_warning "Hook script is not executable: $_hook"
+        print_warning "     -> Run 'chmod +x $_hook' to enable it."
+    done
+}
+
+# Warn when the OpenCode local override file has insecure permissions.
+_warn_insecure_opencode_override() {
+    _override="${USER_CFG_D}/agents/opencode/config.local.override.json"
+    [ -f "$_override" ] || return 0
+    _mode="$(_file_mode "$_override" 2>/dev/null || true)"
+    case "$_mode" in
+        600|0600) ;;
+        *)
+            print_warning "Insecure OpenCode local override permissions: $_override"
+            print_warning "     -> Use 'chmod 600 $_override'."
+            ;;
+    esac
+}
+
+# Run all local customization pre-flight checks. Called before run/build.
+_validate_local_customization() {
+    [ -d "$USER_CFG_D" ] || return 0
+
+    _warn_non_executable_hooks "${USER_CFG_D}/entrypoint.pre.d"
+    _warn_non_executable_hooks "${USER_CFG_D}/entrypoint.post.d"
+    _warn_insecure_opencode_override
+
+    if _local_overlay_enabled && ! _local_image_exists; then
+        print_warning "Containerfile.local exists but local image is missing."
+        if [ "$ACTION" = "build" ]; then
+            print_warning "     -> Build will create '${IMG_NAME}-local:latest'."
+        else
+            print_warning \
+                "     -> Run 'sh ai-agents-sandbox.sh build ${AGENT}'."
+        fi
+    fi
+}
+
+# Return 0 when a local Containerfile overlay is present.
+_local_overlay_enabled() {
+    [ -f "$LOCAL_CONTAINERFILE" ]
+}
+
+# Print the name of the local overlay image.
+_local_image_name() {
+    printf "%s-local" "$IMG_NAME"
+}
+
+# Return 0 when the local overlay image exists in the local podman store.
+_local_image_exists() {
+    podman image exists "$(_local_image_name):latest"
+}
+
+# Build the local overlay image on top of the base image.
+_build_local_overlay() {
+    _local_img_name="$(_local_image_name)"
+    print_info \
+        "Building local overlay image ${_local_img_name}:${IMG_TAG} ..."
+    if ! podman build \
+        --build-arg "BASE_IMAGE=${IMG_NAME}:${IMG_TAG}" \
+        --tag "${_local_img_name}:${IMG_TAG}" \
+        --tag "${_local_img_name}:latest" \
+        --file "$LOCAL_CONTAINERFILE" \
+        "$USER_CFG_D"; then
+        print_error "Local overlay build failed."
+        return "$FAILURE"
+    fi
+    print_info "Local overlay image built successfully."
+    return "$SUCCESS"
+}

--- a/tests/opencode-bootstrap-test.sh
+++ b/tests/opencode-bootstrap-test.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+# Validate OpenCode bootstrap base rendering and local override merge.
+# This test runs the OpenCode bootstrap script with a controlled environment and verifies that:
+# - The base config is rendered correctly from the template with environment variable substitution.
+# - A local override file can be merged correctly, with the expected precedence and structure.
+
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/image/scripts/opencode-bootstrap.sh"
+
+fail() {
+    printf '[FAIL] %s\n' "$1" >&2
+    exit 1
+}
+
+assert_eq() {
+    _expected="$1"
+    _actual="$2"
+    _label="$3"
+    if [ "$_expected" != "$_actual" ]; then
+        fail "${_label}: expected '${_expected}', got '${_actual}'"
+    fi
+}
+
+assert_nonempty_file() {
+    _path="$1"
+    _label="$2"
+    [ -s "$_path" ] || fail "${_label}: missing or empty file $_path"
+}
+
+TMP_D="$(mktemp -d)"
+trap 'rm -rf "$TMP_D"' EXIT
+
+HOME_D="${TMP_D}/home"
+LOCAL_IMAGE_D="${TMP_D}/local-image"
+LOCAL_HOST_D="${TMP_D}/local-host"
+TEMPLATE_FILE="${TMP_D}/config.template.json"
+
+mkdir -p "${HOME_D}" "${LOCAL_IMAGE_D}" "${LOCAL_HOST_D}"
+
+cat > "${TEMPLATE_FILE}" << 'EOF'
+{
+    "$schema": "https://opencode.ai/config.json",
+    "provider": {
+        "google-vertex": {
+            "options": {
+                "projectId": "${GOOGLE_CLOUD_PROJECT}",
+                "location": "${VERTEX_LOCATION}"
+            }
+        }
+    },
+    "model": "google-vertex/gemini-2.0-flash"
+}
+EOF
+
+GOOGLE_CLOUD_PROJECT="proj-base" \
+VERTEX_LOCATION="europe-west1" \
+HOME="${HOME_D}" \
+OPENCODE_LOCAL_IMAGE_DIR="${LOCAL_IMAGE_D}" \
+OPENCODE_LOCAL_HOST_DIR="${LOCAL_HOST_D}" \
+OPENCODE_TEMPLATE_FILE="${TEMPLATE_FILE}" \
+sh "${SCRIPT_PATH}"
+
+BASE_CFG="${HOME_D}/.config/opencode/config.json"
+LEGACY_CFG="${HOME_D}/.config/opencode/opencode.json"
+
+assert_nonempty_file "${BASE_CFG}" "base config"
+assert_nonempty_file "${LEGACY_CFG}" "legacy config"
+
+_base_project="$(jq -r '.provider["google-vertex"].options.projectId' "${BASE_CFG}")"
+_base_location="$(jq -r '.provider["google-vertex"].options.location' "${BASE_CFG}")"
+assert_eq "proj-base" "${_base_project}" "base projectId render"
+assert_eq "europe-west1" "${_base_location}" "base location render"
+
+mkdir -p "${LOCAL_HOST_D}/agents/opencode"
+cat > "${LOCAL_HOST_D}/agents/opencode/config.local.override.json" << 'EOF'
+{
+    "model": "google-vertex/gemini-2.5-pro",
+    "mcp": {
+        "jenkins": {
+            "type": "remote",
+            "url": "https://jenkins.example/mcp"
+        }
+    },
+    "lsp": {
+        "gopls": {
+            "disabled": false,
+            "command": ["gopls"]
+        }
+    }
+}
+EOF
+chmod 600 "${LOCAL_HOST_D}/agents/opencode/config.local.override.json"
+
+GOOGLE_CLOUD_PROJECT="proj-merged" \
+VERTEX_LOCATION="global" \
+HOME="${HOME_D}" \
+OPENCODE_LOCAL_IMAGE_DIR="${LOCAL_IMAGE_D}" \
+OPENCODE_LOCAL_HOST_DIR="${LOCAL_HOST_D}" \
+OPENCODE_TEMPLATE_FILE="${TEMPLATE_FILE}" \
+sh "${SCRIPT_PATH}"
+
+_merged_model="$(jq -r '.model' "${BASE_CFG}")"
+_merged_project="$(jq -r '.provider["google-vertex"].options.projectId' "${BASE_CFG}")"
+_mcp_url="$(jq -r '.mcp.jenkins.url' "${BASE_CFG}")"
+_lsp_cmd="$(jq -r '.lsp.gopls.command[0]' "${BASE_CFG}")"
+
+assert_eq "google-vertex/gemini-2.5-pro" "${_merged_model}" "model override"
+assert_eq "proj-merged" "${_merged_project}" "base provider preserved"
+assert_eq "https://jenkins.example/mcp" "${_mcp_url}" "mcp merge"
+assert_eq "gopls" "${_lsp_cmd}" "lsp merge"
+
+printf '[PASS] opencode-bootstrap base render + local merge\n'

--- a/tests/opencode-bootstrap-test.sh
+++ b/tests/opencode-bootstrap-test.sh
@@ -80,7 +80,10 @@ cat > "${LOCAL_HOST_D}/agents/opencode/config.local.override.json" << 'EOF'
     "mcp": {
         "jenkins": {
             "type": "remote",
-            "url": "https://jenkins.example/mcp"
+            "url": "https://${JENKINS_HOST}/mcp",
+            "headers": {
+                "Authorization": "Bearer ${JENKINS_TOKEN}"
+            }
         }
     },
     "lsp": {
@@ -95,6 +98,8 @@ chmod 600 "${LOCAL_HOST_D}/agents/opencode/config.local.override.json"
 
 GOOGLE_CLOUD_PROJECT="proj-merged" \
 VERTEX_LOCATION="global" \
+JENKINS_HOST="jenkins.example" \
+JENKINS_TOKEN="token-123" \
 HOME="${HOME_D}" \
 OPENCODE_LOCAL_IMAGE_DIR="${LOCAL_IMAGE_D}" \
 OPENCODE_LOCAL_HOST_DIR="${LOCAL_HOST_D}" \
@@ -104,11 +109,13 @@ sh "${SCRIPT_PATH}"
 _merged_model="$(jq -r '.model' "${BASE_CFG}")"
 _merged_project="$(jq -r '.provider["google-vertex"].options.projectId' "${BASE_CFG}")"
 _mcp_url="$(jq -r '.mcp.jenkins.url' "${BASE_CFG}")"
+_mcp_auth="$(jq -r '.mcp.jenkins.headers.Authorization' "${BASE_CFG}")"
 _lsp_cmd="$(jq -r '.lsp.gopls.command[0]' "${BASE_CFG}")"
 
 assert_eq "google-vertex/gemini-2.5-pro" "${_merged_model}" "model override"
 assert_eq "proj-merged" "${_merged_project}" "base provider preserved"
 assert_eq "https://jenkins.example/mcp" "${_mcp_url}" "mcp merge"
+assert_eq "Bearer token-123" "${_mcp_auth}" "override env expansion"
 assert_eq "gopls" "${_lsp_cmd}" "lsp merge"
 
 printf '[PASS] opencode-bootstrap base render + local merge\n'


### PR DESCRIPTION
## Proposed changes

This PR introduces a robust "Custom Local Config" system, providing users with a native, structured way to customize their sandbox environment, tools, and per-agent configurations without having to modify tracked repository files or maintain personal forks.

The system supports two layers of customization:
1. **Container Image Customizations:** By providing a `.ai-agents-sandbox/Containerfile.local`, users can build a derived image (`ai-agents-sandbox[-<agent>]-local:latest`) extending the base sandbox image. This enables persistent installation of custom packages or system binaries. The `run` command automatically detects and prefers the `-local` image variant if it exists.
2. **Runtime Local Overlays & Hooks:** Introduces support for pre- and post-entrypoint hook scripts (`entrypoint.pre.d/`, `entrypoint.post.d/`) and per-agent configuration overrides. These overlays can be either baked into the image or mounted directly from the host, with host overlays taking precedence.

**Underlying mechanisms & Key updates:**
- **Local Overlays (`.ai-agents-sandbox`):** This directory structure is explicitly `.gitignore`d (excluding `templates/`) to provide a safe place for personal overrides and secrets.
- **Hook Scripts & Provisioning:** Extracted logic into `local-customization.sh` and `local-provision.sh` to handle hook invocation, image existence validation, and base/overlay agent provisioning.
- **OpenCode Bootstrap:** Replaced static OpenCode configuration with a dynamic `opencode-bootstrap.sh` script that renders templates based on environment variables and deeply merges JSON using `jq` with `config.local.override.json`. Added test fir opencode config (`tests/opencode-bootstrap-test.sh`).
- **CI/CD:** Extended `ci.yml` ShellCheck assertions to cover all new scripts and added automated test execution for OpenCode bootstrap merging logic.

## Types of changes

What types of changes does your code introduce to ai-agents-sandbox?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Typo fix (non-breaking change which fixes a typo)
- [x] Code refactor (non-breaking change which restructures existing code
      without changing its behavior)
- [x] Documentation Update (non-breaking change which updates documentation)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [x] I have ran the `shellcheck` script to check for shell script issues.
- [x] I have updated the documentation accordingly.

## Further comments

This approach ensures the project remains easily upgradeable for users while giving them the necessary flexibility to tailor the environment to their specific needs. Using `jq` to dynamically merge OpenCode's configuration makes the system robust against future schema enhancements and simplifies local integration scenarios like setting custom Language Servers or MCP servers. All boilerplate and instructions have been documented inside `.ai-agents-sandbox/templates/` and `README.md`.
